### PR TITLE
Ignore runtime exception in coverage report.

### DIFF
--- a/{{ cookiecutter.project_name }}/.coveragerc
+++ b/{{ cookiecutter.project_name }}/.coveragerc
@@ -14,3 +14,8 @@ source =
 source =
   src
   .tox/*/site-packages
+
+[report]
+exclude_lines =
+  pragma: no cover
+  raise RuntimeError


### PR DESCRIPTION
Resolves #89